### PR TITLE
add issue_management field to pom schema

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -17,6 +17,8 @@ pub struct Project {
     pub group_id: Option<String>,
     #[serde(rename = "inceptionYear")]
     pub inception_year: Option<String>,
+    #[serde(rename = "issueManagement")]
+    pub issue_management: Option<IssueManagement>,
     pub licenses: Option<Licenses>,
     #[serde(rename = "modelVersion")]
     pub model_version: String,
@@ -46,6 +48,12 @@ pub struct License {
     pub comments: Option<String>,
     pub distribution: Option<String>,
     pub name: String,
+    pub url: Option<String>,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct IssueManagement {
+    pub system: Option<String>,
     pub url: Option<String>,
 }
 


### PR DESCRIPTION
This simply adds the issue_management fields to the pom schema, which allows for linking Bugzilla, Jira, issues, etc.

Upstream documentation from Apache Maven for the structure of this field can be found [here](https://maven.apache.org/pom.html#Issue_Management).

