### PR TITLE
bump maven-bundle-plugin test pom from 4.x to 6.0.1

### DIFF
--- a/tests/data/maven-bundle-plugin-6.0.1/pom.xml
+++ b/tests/data/maven-bundle-plugin-6.0.1/pom.xml
@@ -21,14 +21,14 @@
  <parent>
    <artifactId>felix-parent</artifactId>
    <groupId>org.apache.felix</groupId>
-   <version>6</version>
+   <version>9</version>
    <relativePath>../../pom/pom.xml</relativePath>
  </parent>
 
  <modelVersion>4.0.0</modelVersion>
 
  <artifactId>maven-bundle-plugin</artifactId>
- <version>4.2.1</version>
+ <version>6.0.1-SNAPSHOT</version>
  <packaging>maven-plugin</packaging>
 
  <name>Maven Bundle Plugin</name>
@@ -38,26 +38,28 @@
   resources and dependencies. Plus a zillion other features.
   The plugin uses the Bnd tool (http://www.aqute.biz/Code/Bnd)
  </description>
- 
+
  <url>http://felix.apache.org/components/bundle-plugin/</url>
 
  <scm>
-     <connection>scm:svn:http://svn.apache.org/repos/asf/felix/releases/maven-bundle-plugin-4.2.1</connection>
-     <developerConnection>scm:svn:https://svn.apache.org/repos/asf/felix/releases/maven-bundle-plugin-4.2.1</developerConnection>
-     <url>http://svn.apache.org/viewvc/felix/releases/maven-bundle-plugin-4.2.1</url>
- </scm>
+     <connection>scm:git:https://github.com/apache/felix-dev.git</connection>
+     <developerConnection>scm:git:https://github.com/apache/felix-dev.git</developerConnection>
+     <url>https://gitbox.apache.org/repos/asf?p=felix-dev.git</url>
+    <tag>maven-bundle-plugin-6.0.0</tag>
+  </scm>
 
  <!-- Support for publishing the mvn site. -->
   <distributionManagement>
     <site>
       <id>apache.website</id>
-      <url>scm:svn:https://svn.apache.org/repos/asf/felix/site/trunk/content/components/${maven.site.path}</url>
+      <url>https://gitbox.apache.org/repos/asf?p=felix-dev.git</url>
     </site>
   </distributionManagement>
 
  <properties>
    <felix.java.version>8</felix.java.version>
    <maven.site.path>bundle-plugin-archives/bundle-plugin-LATEST</maven.site.path>
+   <project.build.outputTimestamp>1732531392</project.build.outputTimestamp>
  </properties>
 
  <build>
@@ -66,7 +68,7 @@
     <plugin>
      <groupId>org.apache.maven.plugins</groupId>
      <artifactId>maven-plugin-plugin</artifactId>
-     <version>3.4</version>
+     <version>3.6.4</version>
      <executions>
       <execution>
        <id>default-descriptor</id>
@@ -74,44 +76,44 @@
       </execution>
      </executions>
     </plugin>
-          <plugin>
-            <artifactId>maven-site-plugin</artifactId>
-            <version>3.4</version>
-            <dependencies>
-              <dependency>
-                <groupId>org.apache.maven</groupId>
-                <artifactId>maven-archiver</artifactId>
-                <version>2.6</version>
-              </dependency>
-              <dependency>
-                <groupId>org.codehaus.plexus</groupId>
-                <artifactId>plexus-archiver</artifactId>
-                <version>4.8.0</version>
-              </dependency>
-              <dependency>
-                <groupId>org.apache.maven.doxia</groupId>
-                <artifactId>doxia-core</artifactId>
-                <version>1.6</version>
-                <exclusions>
-                  <exclusion>
-                    <artifactId>xercesImpl</artifactId>
-                    <groupId>xerces</groupId>
-                  </exclusion>
-                </exclusions>
-              </dependency>
-            </dependencies>
-            <configuration>
-              <topSiteURL>scm:svn:https://svn.apache.org/repos/infra/websites/production/felix/content/components/${maven.site.path}</topSiteURL>
-            </configuration>
-          </plugin>
-          <plugin>
-            <artifactId>maven-scm-publish-plugin</artifactId>
-            <version>1.1</version>
-            <configuration>
-              <checkoutDirectory>${user.home}/maven-sites/${maven.site.path}</checkoutDirectory>
-              <tryUpdate>true</tryUpdate>
-            </configuration>
-          </plugin>
+    <plugin>
+      <artifactId>maven-site-plugin</artifactId>
+      <version>3.4</version>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-archiver</artifactId>
+          <version>2.6</version>
+        </dependency>
+        <dependency>
+          <groupId>org.codehaus.plexus</groupId>
+          <artifactId>plexus-archiver</artifactId>
+          <version>4.8.0</version>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.maven.doxia</groupId>
+          <artifactId>doxia-core</artifactId>
+          <version>1.6</version>
+          <exclusions>
+            <exclusion>
+              <artifactId>xercesImpl</artifactId>
+              <groupId>xerces</groupId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+      </dependencies>
+      <configuration>
+        <topSiteURL>scm:svn:https://svn.apache.org/repos/infra/websites/production/felix/content/components/${maven.site.path}</topSiteURL>
+      </configuration>
+    </plugin>
+    <plugin>
+      <artifactId>maven-scm-publish-plugin</artifactId>
+      <version>1.1</version>
+      <configuration>
+        <checkoutDirectory>${user.home}/maven-sites/${maven.site.path}</checkoutDirectory>
+        <tryUpdate>true</tryUpdate>
+      </configuration>
+    </plugin>
    </plugins>
   </pluginManagement>
   <plugins>
@@ -125,7 +127,9 @@
     <configuration>
      <excludes>
       <exclude>**/*.mf</exclude>
+      <exclude>**/*.MF</exclude>
       <exclude>src/repo/**/*.pom</exclude>
+      <exclude>**/org.apache.felix_maven-bundle-plugin_manifest_xx</exclude>
      </excludes>
     </configuration>
    </plugin>
@@ -133,14 +137,13 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <configuration>
-              <source>8</source>
-              <target>8</target>
+              <source>17</source>
+              <target>17</target>
           </configuration>
       </plugin>
-      <!--
-    <plugin>
+      <plugin>
         <artifactId>maven-invoker-plugin</artifactId>
-        <version>2.0.0</version>
+        <version>3.2.1</version>
         <configuration>
           <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
           <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
@@ -159,7 +162,6 @@
           </execution>
         </executions>
       </plugin>
-      -->
   </plugins>
  </build>
 
@@ -172,13 +174,13 @@
   <dependency>
     <groupId>biz.aQute.bnd</groupId>
     <artifactId>biz.aQute.bndlib</artifactId>
-    <version>4.2.0</version>
+    <version>7.0.0</version>
   </dependency>
-     <dependency>
-         <groupId>org.slf4j</groupId>
-         <artifactId>slf4j-api</artifactId>
-         <version>1.7.25</version>
-     </dependency>
+  <dependency>
+    <groupId>org.slf4j</groupId>
+    <artifactId>slf4j-api</artifactId>
+    <version>1.7.25</version>
+  </dependency>
   <dependency>
     <groupId>org.apache.felix</groupId>
     <artifactId>org.apache.felix.bundlerepository</artifactId>
@@ -190,14 +192,28 @@
     <version>1.6.0</version>
   </dependency>
   <dependency>
-   <groupId>org.apache.maven</groupId>
-   <artifactId>maven-core</artifactId>
-   <version>3.8.1</version>
+    <groupId>org.apache.maven</groupId>
+    <artifactId>maven-core</artifactId>
+    <version>3.8.1</version>
+    <scope>provided</scope>
+  </dependency>
+  <dependency>
+    <groupId>org.apache.maven</groupId>
+    <artifactId>maven-model</artifactId>
+    <version>3.3.9</version>
+    <scope>provided</scope>
+  </dependency>
+  <dependency>
+    <groupId>org.apache.maven</groupId>
+    <artifactId>maven-artifact</artifactId>
+    <version>3.3.9</version>
+    <scope>provided</scope>
   </dependency>
   <dependency>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven-compat</artifactId>
     <version>3.8.1</version>
+    <scope>provided</scope>
   </dependency>
   <dependency>
     <groupId>org.apache.maven.reporting</groupId>
@@ -207,17 +223,17 @@
   <dependency>
    <groupId>org.apache.maven</groupId>
    <artifactId>maven-archiver</artifactId>
-   <version>2.6</version>
+   <version>3.5.2</version>
   </dependency>
   <dependency>
    <groupId>org.apache.maven.shared</groupId>
    <artifactId>maven-dependency-tree</artifactId>
-   <version>2.1</version>
+   <version>3.0</version>
   </dependency>
   <dependency>
    <groupId>org.codehaus.plexus</groupId>
    <artifactId>plexus-utils</artifactId>
-   <version>3.0.24</version>
+   <version>3.3.0</version>
   </dependency>
   <dependency>
    <groupId>org.sonatype.plexus</groupId>
@@ -241,9 +257,9 @@
    <scope>provided</scope>
   </dependency>
   <dependency>
-   <groupId>org.apache.maven.shared</groupId>
+   <groupId>org.apache.maven.plugin-testing</groupId>
    <artifactId>maven-plugin-testing-harness</artifactId>
-   <version>1.1</version>
+   <version>3.3.0</version>
    <scope>test</scope>
   </dependency>
   <dependency>
@@ -253,14 +269,9 @@
    <scope>test</scope>
   </dependency>
   <dependency>
-   <groupId>org.jdom</groupId>
-   <artifactId>jdom</artifactId>
-   <version>1.1</version>
-  </dependency>
-  <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13.1</version>
       <scope>test</scope>
   </dependency>
  </dependencies>
@@ -270,7 +281,6 @@
    <plugin>
     <groupId>org.apache.maven.plugins</groupId>
     <artifactId>maven-plugin-plugin</artifactId>
-    <version>3.4</version>
    </plugin>
    <plugin>
     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This should fix dependabot errors about security vulnerabilities in the test pom files.